### PR TITLE
Update copyright headers to yearless format

### DIFF
--- a/SpectrumCore.podspec
+++ b/SpectrumCore.podspec
@@ -1,4 +1,4 @@
-# Copyright 2004-present Facebook. All Rights Reserved.
+# Copyright (c) Facebook, Inc. and its affiliates.
 
 compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DSPECTRUM_TARGET_IOS -DSPECTRUM_EXTERNAL'
 

--- a/SpectrumKit.podspec
+++ b/SpectrumKit.podspec
@@ -1,4 +1,4 @@
-# Copyright 2004-present Facebook. All Rights Reserved.
+# Copyright (c) Facebook, Inc. and its affiliates.
 
 compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-present, Facebook, Inc.
+ *  Copyright (c) Facebook, Inc. and its affiliates.
  *
  *  This source code is licensed under the MIT license found in the LICENSE
  *  file in the root directory of this source tree.


### PR DESCRIPTION
This change drops the year from the copyright headers.