### PR TITLE
Add CircleCI build steps for Android targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
   deploy-website:
     docker:
       - image: circleci/node:8.11.1
-
     steps:
       - checkout
       - run:
@@ -21,6 +20,20 @@ jobs:
             git config --global user.name "Website Deployment Script"
             echo "machine github.com login docusaurus-bot password $GITHUB_DOCUSAURUS_TOKEN" > ~/.netrc
             cd website && yarn install && GIT_USER=docusaurus-bot USE_SSH=false yarn run publish-gh-pages
+
+  build-android-release:
+    docker:
+      - image: circleci/android:api-28-ndk-r17b
+    steps:
+      - checkout
+      - run: ./gradlew assembleRelease
+
+  build-android-sample-app:
+    docker:
+      - image: circleci/android:api-28-ndk-r17b
+    steps:
+      - checkout
+      - run: ./gradlew android:sample:assembleDebug
 
 workflows:
   version: 2

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,21 +12,21 @@ project(spectrumcpp CXX)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 file(GLOB spectrumcpp_SOURCES
-  Spectrum/*.cpp
-  Spectrum/codecs/*.cpp
-  Spectrum/codecs/bitmap/*.cpp
-  Spectrum/codecs/isobmff/*.cpp
-  Spectrum/core/*.cpp
-  Spectrum/core/decisions/*.cpp
-  Spectrum/core/matchers/*.cpp
-  Spectrum/core/recipes/*.cpp
-  Spectrum/core/proc/*.cpp
-  Spectrum/core/proc/legacy/*.cpp
-  Spectrum/core/utils/*.cpp
-  Spectrum/image/*.cpp
-  Spectrum/image/metadata/*.cpp
-  Spectrum/io/*.cpp
-  Spectrum/requirements/*.cpp
+  spectrum/*.cpp
+  spectrum/codecs/*.cpp
+  spectrum/codecs/bitmap/*.cpp
+  spectrum/codecs/isobmff/*.cpp
+  spectrum/core/*.cpp
+  spectrum/core/decisions/*.cpp
+  spectrum/core/matchers/*.cpp
+  spectrum/core/recipes/*.cpp
+  spectrum/core/proc/*.cpp
+  spectrum/core/proc/legacy/*.cpp
+  spectrum/core/utils/*.cpp
+  spectrum/image/*.cpp
+  spectrum/image/metadata/*.cpp
+  spectrum/io/*.cpp
+  spectrum/requirements/*.cpp
 )
 
 add_library(spectrumcpp SHARED


### PR DESCRIPTION
Summary: Adding two jobs to CircleCI to verify the open-source build.

Reviewed By: passy

Differential Revision: D13304104
