### PR TITLE
Add compression level configuration support for PNG compressor

### DIFF
--- a/android/sample/src/main/java/com/facebook/spectrum/sample/model/ConfigurationViewModel.kt
+++ b/android/sample/src/main/java/com/facebook/spectrum/sample/model/ConfigurationViewModel.kt
@@ -74,6 +74,13 @@ enum class ConfigurationViewModel {
             EnumParameterEntry("4:4:4", "1 luma information per chroma information", ImageChromaSamplingMode.S444)
     )
 
+    private val pngCompressionLevel: Array<EnumParameterEntry<Int>> = arrayOf(
+            EnumParameterEntry("Default", null, -1),
+            EnumParameterEntry("Compression level = 0", "No compression", 0),
+            EnumParameterEntry("Compression level = 1", "Best speed", 1),
+            EnumParameterEntry("Compression level = 9", "Best compression", 9)
+    )
+
     private val webpMethodEntries: Array<EnumParameterEntry<Int>> = arrayOf(
             EnumParameterEntry("Default", null, null as Int?),
             EnumParameterEntry("Webp method = 0", "Slowest", 0),
@@ -103,7 +110,8 @@ enum class ConfigurationViewModel {
                     BooleanParameter("PSNR optimised quantisation table", false) { cb, v -> cb.setUsePsnrQuantTable(v) })
             ),
             ParameterGroup("Png", arrayOf(
-                    BooleanParameter("Save with interlacing", false) { cb, v -> cb.setUseInterlacing(v) })
+                    BooleanParameter("Save with interlacing", false) { cb, v -> cb.setUseInterlacing(v) },
+                    EnumParameter("Compression level", pngCompressionLevel) { cb, v -> cb.setCompressionLevel(v) })
             ),
             ParameterGroup("WebP", arrayOf(
                     EnumParameter("Webp compression method", webpMethodEntries) { cb, v -> v?.let { cb.setWebpMethod(it) } },

--- a/android/src/main/java/com/facebook/spectrum/Configuration.java
+++ b/android/src/main/java/com/facebook/spectrum/Configuration.java
@@ -10,6 +10,8 @@ package com.facebook.spectrum;
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.spectrum.image.ImageChromaSamplingMode;
 import com.facebook.spectrum.image.ImageColor;
+import com.facebook.spectrum.utils.Preconditions;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -72,6 +74,13 @@ public class Configuration {
   @DoNotStrip @Nullable public final Boolean useInterlacing;
 
   /**
+   * Png: The compression level that is used by zlib to determine
+   * how much time to spend on trying to compress the image data.
+   * 0 is for not using compression at all and 9 is for the best compression.
+   */
+  @DoNotStrip @Nullable public final Integer compressionLevel;
+
+  /**
    * Webp: Compression quality/speed tradeoff where 0 is the fastest and 6 is the slowest/best
    * compression.
    */
@@ -93,6 +102,7 @@ public class Configuration {
       @Nullable Boolean useCompatibleDcScanOpt,
       @Nullable Boolean usePsnrQuantTable,
       @Nullable Boolean useInterlacing,
+      @Nullable Integer compressionLevel,
       @Nullable Integer webpMethod,
       @Nullable ImageHint webpImageHint) {
     this.defaultBackgroundColor = defaultBackgroundColor;
@@ -106,6 +116,7 @@ public class Configuration {
     this.chromaSamplingModeOverride = chromaSamplingModeOverride;
     this.usePsnrQuantTable = usePsnrQuantTable;
     this.useInterlacing = useInterlacing;
+    this.compressionLevel = compressionLevel;
     this.webpMethod = webpMethod;
     this.webpImageHint = webpImageHint;
   }
@@ -139,6 +150,8 @@ public class Configuration {
         + usePsnrQuantTable
         + ", useInterlacing="
         + useInterlacing
+        + ", compressionLevel="
+        + compressionLevel
         + ", webpMethod="
         + webpMethod
         + ", webpImageHint="
@@ -172,6 +185,7 @@ public class Configuration {
     @Nullable private Boolean mUseCompatibleDcScanOpt;
     @Nullable private Boolean mUsePsnrQuantTable;
     @Nullable private Boolean mUseInterlacing;
+    @Nullable private Integer mCompressionLevel;
     @Nullable private Integer mWebpMethod;
     @Nullable private ImageHint mWebpImageHint;
 
@@ -258,6 +272,17 @@ public class Configuration {
     }
 
     /**
+     * Png: The compression level that is used by zlib to determine
+     * how much time to spend on trying to compress the image data.
+     * 0 is for not using compression at all and 9 is for the best compression.
+     */
+    public Builder setCompressionLevel(final Integer compressionLevel) {
+      Preconditions.checkArgument(compressionLevel >= -1 && compressionLevel <= 9);
+      mCompressionLevel = compressionLevel;
+      return this;
+    }
+
+    /**
      * Webp: Compression quality/speed tradeoff where 0 is the fastest and 6 is the slowest/best
      * compression.
      */
@@ -290,6 +315,7 @@ public class Configuration {
           mUseCompatibleDcScanOpt,
           mUsePsnrQuantTable,
           mUseInterlacing,
+          mCompressionLevel,
           mWebpMethod,
           mWebpImageHint);
     }
@@ -398,6 +424,9 @@ public class Configuration {
     if (useInterlacing != null
         ? !useInterlacing.equals(that.useInterlacing)
         : that.useInterlacing != null) return false;
+    if (compressionLevel != null
+        ? !compressionLevel.equals(that.compressionLevel)
+        : that.compressionLevel != null) return false;
     if (webpMethod != null ? !webpMethod.equals(that.webpMethod) : that.webpMethod != null)
       return false;
     return webpImageHint == that.webpImageHint;

--- a/android/src/main/java/com/facebook/spectrum/Configuration.java
+++ b/android/src/main/java/com/facebook/spectrum/Configuration.java
@@ -277,7 +277,7 @@ public class Configuration {
      * 0 is for not using compression at all and 9 is for the best compression.
      */
     public Builder setCompressionLevel(final Integer compressionLevel) {
-      Preconditions.checkArgument(compressionLevel <= 9);
+      Preconditions.checkArgument(compressionLevel >= 0 && compressionLevel <= 9);
       mCompressionLevel = compressionLevel;
       return this;
     }

--- a/android/src/main/java/com/facebook/spectrum/Configuration.java
+++ b/android/src/main/java/com/facebook/spectrum/Configuration.java
@@ -277,7 +277,7 @@ public class Configuration {
      * 0 is for not using compression at all and 9 is for the best compression.
      */
     public Builder setCompressionLevel(final Integer compressionLevel) {
-      Preconditions.checkArgument(compressionLevel >= -1 && compressionLevel <= 9);
+      Preconditions.checkArgument(compressionLevel <= 9);
       mCompressionLevel = compressionLevel;
       return this;
     }

--- a/android/src/test/java/com/facebook/spectrum/ConfigurationTest.java
+++ b/android/src/test/java/com/facebook/spectrum/ConfigurationTest.java
@@ -33,6 +33,7 @@ public class ConfigurationTest {
     assertThat(configuration.chromaSamplingModeOverride).isNull();
     assertThat(configuration.usePsnrQuantTable).isNull();
     assertThat(configuration.useInterlacing).isNull();
+    assertThat(configuration.compressionLevel).isNull();
     assertThat(configuration.defaultBackgroundColor).isNull();
     assertThat(configuration.webpMethod).isNull();
     assertThat(configuration.webpImageHint).isNull();
@@ -53,6 +54,7 @@ public class ConfigurationTest {
             .setChromaSamplingModeOverride(ImageChromaSamplingMode.S444)
             .setUsePsnrQuantTable(true)
             .setUseInterlacing(true)
+            .setCompressionLevel(9)
             .setWebpMethod(1)
             .setWebpImageHint(Configuration.ImageHint.DEFAULT)
             .build();
@@ -68,6 +70,7 @@ public class ConfigurationTest {
     assertThat(configuration.chromaSamplingModeOverride).isEqualTo(ImageChromaSamplingMode.S444);
     assertThat(configuration.usePsnrQuantTable).isTrue();
     assertThat(configuration.useInterlacing).isTrue();
+    assertThat(configuration.compressionLevel).isEqualTo(9);
     assertThat(configuration.defaultBackgroundColor).isNotNull();
     assertThat(configuration.defaultBackgroundColor.red).isEqualTo(12);
     assertThat(configuration.defaultBackgroundColor.green).isEqualTo(34);

--- a/cpp/spectrum/Configuration.cpp
+++ b/cpp/spectrum/Configuration.cpp
@@ -175,10 +175,12 @@ bool Configuration::Jpeg::operator==(const Jpeg& rhs) const {
 
 void Configuration::Png::merge(const Png& rhs) {
   SPECTRUM_CONFIGURATION_MERGE_PROPERTY(useInterlacing, rhs);
+  SPECTRUM_CONFIGURATION_MERGE_PROPERTY(compressionLevel, rhs);
 }
 
 bool Configuration::Png::operator==(const Png& rhs) const {
-  return SPECTRUM_CONFIGURATION_COMPARE_PROPERTY(useInterlacing, rhs);
+  return SPECTRUM_CONFIGURATION_COMPARE_PROPERTY(useInterlacing, rhs) &&
+      SPECTRUM_CONFIGURATION_COMPARE_PROPERTY(compressionLevel, rhs);
 }
 
 //

--- a/cpp/spectrum/Configuration.h
+++ b/cpp/spectrum/Configuration.h
@@ -195,6 +195,13 @@ struct Configuration {
   // LibPng parameters
   //
   struct Png {
+    using CompressionLevel = int;
+    
+    static constexpr CompressionLevel CompressionLevelNone = 0;
+    static constexpr CompressionLevel CompressionLevelBestSpeed = 1;
+    static constexpr CompressionLevel CompressionLevelBestCompression = 9;
+    static constexpr CompressionLevel CompressionLevelDefault = -1;
+    
     /**
      * Whether to save PNG images with interlaced encoding.
      */
@@ -202,6 +209,16 @@ struct Configuration {
         bool,
         useInterlacing,
         false);
+      
+    /**
+     * The compression level that is used by zlib to determine
+     * how much time to spend on trying to compress the image data.
+     * 0 is for not using compression at all and 9 is for the best compression.
+     */
+    SPECTRUM_CONFIGURATION_MAKE_PROPERTY_W_DEFAULTS(
+        CompressionLevel,
+        compressionLevel,
+        -1);
 
     void merge(const Png& rhs);
     bool operator==(const Png& rhs) const;

--- a/cpp/spectrum/plugins/png/LibPngCompressor.cpp
+++ b/cpp/spectrum/plugins/png/LibPngCompressor.cpp
@@ -108,6 +108,10 @@ LibPngCompressor::LibPngCompressor(const codecs::CompressorOptions& options)
         codecs::error::CompressorFailure, "png_create_info_struct_failed");
   }
 
+  png_set_compression_level(
+      libPngWriteStruct,
+      options.configuration.png.compressionLevel());
+  
   png_set_write_fn(
       libPngWriteStruct,
       &options.sink,

--- a/cpp/test/unit/ConfigurationTest.cpp
+++ b/cpp/test/unit/ConfigurationTest.cpp
@@ -74,6 +74,8 @@ TEST(Configuration, whenRequestingDefaultValue_allParametersAreCorrect) {
 
   // Png
   ASSERT_EQ(false, configuration.png.useInterlacing());
+  ASSERT_EQ(
+      Configuration::Png::CompressionLevelDefault, configuration.png.compressionLevel());
 
   // WebP
   ASSERT_EQ(3, configuration.webp.method());
@@ -148,6 +150,15 @@ TEST(
     Configuration_Png,
     whenMergingOrComparing_thenUseInterlacingIsAccountedFor) {
   SPECTRUM_CONFIGURATION_TEST_PROPERTY(bool, png.useInterlacing, true);
+}
+
+TEST(
+    Configuration_Png,
+    whenMergingOrComparing_thenCompressionLevelIsAccountedFor) {
+  SPECTRUM_CONFIGURATION_TEST_PROPERTY(
+      Configuration::Png::CompressionLevel,
+      png.compressionLevel,
+      Configuration::Png::CompressionLevelBestCompression);
 }
 
 TEST(Configuration_WebP, whenMergingOrComparing_thenMethodAccountedFor) {

--- a/ios/SpectrumKit/SpectrumKit/Configuration/FSPConfigurationPng.h
+++ b/ios/SpectrumKit/SpectrumKit/Configuration/FSPConfigurationPng.h
@@ -8,12 +8,21 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NSInteger FSPPngCompressionLevel NS_SWIFT_NAME(PngCompressionLevel);
+
+extern const FSPPngCompressionLevel FSPPngCompressionLevelNone NS_SWIFT_NAME(PngCompressionLevelNone);
+extern const FSPPngCompressionLevel FSPPngCompressionLevelBestSpeed NS_SWIFT_NAME(CompressionLevelBestSpeed);
+extern const FSPPngCompressionLevel FSPPngCompressionLevelBestCompression NS_SWIFT_NAME(CompressionLevelBestCompression);
+extern const FSPPngCompressionLevel FSPPngCompressionLevelDefault NS_SWIFT_NAME(CompressionLevelDefault);
+
 NS_SWIFT_NAME(ConfigurationPng)
 @interface FSPConfigurationPng : NSObject <NSCopying>
 
 @property (nonatomic, assign) BOOL useInterlacing;
+@property (nonatomic, assign) FSPPngCompressionLevel compressionLevel;
 
-- (instancetype)initWithUseInterlacing:(BOOL)useInterlacing;
+- (instancetype)initWithUseInterlacing:(BOOL)useInterlacing
+                      compressionLevel:(FSPPngCompressionLevel)compressionLevel;
 
 - (BOOL)isEqualToConfigurationPng:(FSPConfigurationPng *)object;
 

--- a/ios/SpectrumKit/SpectrumKit/Configuration/FSPConfigurationPng.h
+++ b/ios/SpectrumKit/SpectrumKit/Configuration/FSPConfigurationPng.h
@@ -11,9 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSInteger FSPPngCompressionLevel NS_SWIFT_NAME(PngCompressionLevel);
 
 extern const FSPPngCompressionLevel FSPPngCompressionLevelNone NS_SWIFT_NAME(PngCompressionLevelNone);
-extern const FSPPngCompressionLevel FSPPngCompressionLevelBestSpeed NS_SWIFT_NAME(CompressionLevelBestSpeed);
-extern const FSPPngCompressionLevel FSPPngCompressionLevelBestCompression NS_SWIFT_NAME(CompressionLevelBestCompression);
-extern const FSPPngCompressionLevel FSPPngCompressionLevelDefault NS_SWIFT_NAME(CompressionLevelDefault);
+extern const FSPPngCompressionLevel FSPPngCompressionLevelBestSpeed NS_SWIFT_NAME(PngCompressionLevelBestSpeed);
+extern const FSPPngCompressionLevel FSPPngCompressionLevelBestCompression NS_SWIFT_NAME(PngCompressionLevelBestCompression);
+extern const FSPPngCompressionLevel FSPPngCompressionLevelDefault NS_SWIFT_NAME(PngCompressionLevelDefault);
 
 NS_SWIFT_NAME(ConfigurationPng)
 @interface FSPConfigurationPng : NSObject <NSCopying>

--- a/ios/SpectrumKit/SpectrumKit/Configuration/FSPConfigurationPng.mm
+++ b/ios/SpectrumKit/SpectrumKit/Configuration/FSPConfigurationPng.mm
@@ -9,7 +9,14 @@
 
 #import <spectrum/Configuration.h>
 
+#import "FSPLog.h"
+
 using namespace facebook::spectrum;
+
+const NSInteger FSPPngCompressionLevelNone = Configuration::Png::CompressionLevelNone;
+const NSInteger FSPPngCompressionLevelBestSpeed = Configuration::Png::CompressionLevelBestSpeed;
+const NSInteger FSPPngCompressionLevelBestCompression = Configuration::Png::CompressionLevelBestCompression;
+const NSInteger FSPPngCompressionLevelDefault = Configuration::Png::CompressionLevelDefault;
 
 @interface FSPConfigurationPng()
 
@@ -20,9 +27,14 @@ using namespace facebook::spectrum;
 @implementation FSPConfigurationPng
 
 - (instancetype)initWithUseInterlacing:(BOOL)useInterlacing
+                      compressionLevel:(FSPPngCompressionLevel)compressionLevel
 {
+  FSPReportMustFixIf(compressionLevel < FSPPngCompressionLevelDefault, nil);
+  FSPReportMustFixIf(compressionLevel > FSPPngCompressionLevelBestCompression, nil);
+
   if (self = [super init]) {
     self.useInterlacing = useInterlacing;
+    self.compressionLevel = compressionLevel;
   }
 
   return self;
@@ -38,6 +50,19 @@ using namespace facebook::spectrum;
 - (BOOL)useInterlacing
 {
   return _configuration.useInterlacing();
+}
+
+- (void)setCompressionLevel:(FSPPngCompressionLevel)compressionLevel
+{
+  FSPReportMustFixIf(compressionLevel < FSPPngCompressionLevelDefault, nil);
+  FSPReportMustFixIf(compressionLevel > FSPPngCompressionLevelBestCompression, nil);
+    
+  _configuration.compressionLevel(SPECTRUM_CONVERT_OR_THROW(compressionLevel, Configuration::Png::CompressionLevel));
+}
+
+- (FSPPngCompressionLevel)compressionLevel
+{
+  return _configuration.compressionLevel();
 }
 
 #pragma mark - Equality
@@ -75,7 +100,8 @@ using namespace facebook::spectrum;
 
 - (id)copyWithZone:(__unused NSZone *)zone
 {
-  return [[[self class] allocWithZone:zone] initWithUseInterlacing:self.useInterlacing];
+  return [[[self class] allocWithZone:zone] initWithUseInterlacing:self.useInterlacing
+                                                  compressionLevel:self.compressionLevel];
 }
 
 #pragma mark - Internal

--- a/ios/SpectrumKit/SpectrumKitTests/FSPConfigurationTests.mm
+++ b/ios/SpectrumKit/SpectrumKitTests/FSPConfigurationTests.mm
@@ -31,6 +31,7 @@ using namespace facebook::spectrum;
   XCTAssertEqual(configuration.jpeg.usePSNRQuantTable, NO);
 
   XCTAssertEqual(configuration.png.useInterlacing, NO);
+  XCTAssertEqual(configuration.png.compressionLevel, FSPPngCompressionLevelDefault);
 
   XCTAssertEqual(configuration.webp.method, 3);
   XCTAssertEqual(configuration.webp.imageHint, FSPConfigurationWebpImageHintDefault);
@@ -160,6 +161,16 @@ using namespace facebook::spectrum;
   XCTAssertNotEqualObjects(object, object2);
 }
 
+- (void)testIsNotEqualOnDifferentPngCompressionLevel
+{
+  const auto object = makeDefaultConfiguration();
+  const auto object2 = makeDefaultConfiguration();
+    
+  object2.png.compressionLevel = FSPPngCompressionLevelBestSpeed;
+    
+  XCTAssertNotEqualObjects(object, object2);
+}
+
 - (void)testIsNotEqualOnDifferentWebpMethod
 {
   const auto object = makeDefaultConfiguration();
@@ -196,6 +207,7 @@ static Configuration makeDefaultInternalConfiguration()
   configuration.jpeg.useCompatibleDcScanOpt(true);
   configuration.jpeg.usePsnrQuantTable(true);
   configuration.png.useInterlacing(true);
+  configuration.png.compressionLevel(Configuration::Png::CompressionLevelBestCompression);
   configuration.webp.method(2);
   configuration.webp.imageHint(Configuration::Webp::ImageHint::Photo);
   return configuration;
@@ -212,7 +224,8 @@ static FSPConfiguration *makeDefaultConfiguration()
                                                                   useOptimizeScan:NO
                                                         useCompatibleDCScanOption:YES
                                                                 usePSNRQuantTable:YES];
-  const auto pngConfiguration = [[FSPConfigurationPng alloc] initWithUseInterlacing:YES];
+  const auto pngConfiguration = [[FSPConfigurationPng alloc] initWithUseInterlacing:YES
+                                                                   compressionLevel:FSPPngCompressionLevelBestCompression];
   const auto webpConfiguration = [[FSPConfigurationWebp alloc] initWithMethod:2
                                                                     imageHint:FSPConfigurationWebpImageHintPhoto];
   return [[FSPConfiguration alloc] initWithGeneral:generalConfiguration

--- a/ios/SpectrumKitSample/SpectrumKitSample-iOS/Alerts.swift
+++ b/ios/SpectrumKitSample/SpectrumKitSample-iOS/Alerts.swift
@@ -162,6 +162,10 @@ struct Alerts {
   static let configurationGeneralDefaultBackgroundColor = AlertContent(title: NSLocalizedString("Select default background color", comment: "Configuration general background color title"),
                                                                        message: nil,
                                                                        optionsType: ConfigurationViewModel.DefaultBackgroundColor.self)
+  
+  static let configurationPngCompressionLevel = AlertContent(title: NSLocalizedString("Select PNG compression level", comment: "Configuration PNG compression level"),
+                                                             message: nil,
+                                                             optionsType: ConfigurationViewModel.CompressionLevel.self)
 
   static let configurationWebpMethod = AlertContent(title: NSLocalizedString("Select WebP method", comment: "Configuration webp method title"),
                                                     message: nil,

--- a/ios/SpectrumKitSample/SpectrumKitSample-iOS/Base.lproj/Main.storyboard
+++ b/ios/SpectrumKitSample/SpectrumKitSample-iOS/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tr0-bN-DsT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tr0-bN-DsT">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -533,7 +533,7 @@
                                         </subviews>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jS4-BH-ytm">
-                                        <rect key="frame" x="151.5" y="875.5" width="72" height="40"/>
+                                        <rect key="frame" x="20" y="875.5" width="335" height="40"/>
                                         <color key="backgroundColor" red="0.72549019609999998" green="0.27450980390000002" blue="0.60392156860000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="NfJ-5K-VQd"/>
@@ -759,7 +759,7 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="936"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="2vz-hc-TYw">
-                                        <rect key="frame" x="0.0" y="20" width="375" height="777"/>
+                                        <rect key="frame" x="0.0" y="20" width="375" height="824"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wdP-cV-CU0">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
@@ -1187,15 +1187,55 @@
                                                     <constraint firstItem="ESb-YV-bxj" firstAttribute="centerY" secondItem="b41-Wf-ifN" secondAttribute="centerY" id="rmU-Z2-oFB"/>
                                                 </constraints>
                                             </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r51-77-mQa">
+                                                <rect key="frame" x="0.0" y="613" width="375" height="47"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="751" text="Compression Level" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vKb-6T-3OE">
+                                                        <rect key="frame" x="15" y="15" width="122.5" height="17"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <color key="textColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R1j-66-9qf" userLabel="Hairline">
+                                                        <rect key="frame" x="0.0" y="46" width="375" height="1"/>
+                                                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="1" id="vlc-OH-8Rw" customClass="HairlineConstraint" customModule="SpectrumKitSample_iOS" customModuleProvider="target"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zsm-ha-2hY">
+                                                        <rect key="frame" x="147.5" y="9" width="212.5" height="29"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <state key="normal" title="None">
+                                                            <color key="titleColor" white="0.33333333329999998" alpha="1" colorSpace="calibratedWhite"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="didTapImageOptionsButton:" destination="rsD-2W-UkJ" eventType="touchUpInside" id="mcj-CO-QFd"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="trailing" secondItem="Zsm-ha-2hY" secondAttribute="trailing" constant="15" id="66w-cd-VYl"/>
+                                                    <constraint firstItem="Zsm-ha-2hY" firstAttribute="leading" secondItem="vKb-6T-3OE" secondAttribute="trailing" constant="10" id="IUN-CA-Dfp"/>
+                                                    <constraint firstItem="vKb-6T-3OE" firstAttribute="top" secondItem="r51-77-mQa" secondAttribute="top" constant="15" id="KTd-1G-93w"/>
+                                                    <constraint firstItem="vKb-6T-3OE" firstAttribute="leading" secondItem="r51-77-mQa" secondAttribute="leading" constant="15" id="SrA-dp-hh9"/>
+                                                    <constraint firstItem="R1j-66-9qf" firstAttribute="leading" secondItem="r51-77-mQa" secondAttribute="leading" id="Uqw-4B-BgI"/>
+                                                    <constraint firstItem="vKb-6T-3OE" firstAttribute="centerY" secondItem="r51-77-mQa" secondAttribute="centerY" id="Y60-xH-0oN"/>
+                                                    <constraint firstAttribute="bottom" secondItem="R1j-66-9qf" secondAttribute="bottom" id="k82-Hf-gO7"/>
+                                                    <constraint firstItem="Zsm-ha-2hY" firstAttribute="centerY" secondItem="r51-77-mQa" secondAttribute="centerY" id="m3V-qc-WL2"/>
+                                                    <constraint firstAttribute="trailing" secondItem="R1j-66-9qf" secondAttribute="trailing" id="taG-c1-uJW"/>
+                                                </constraints>
+                                            </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ry1-yV-aUk">
-                                                <rect key="frame" x="0.0" y="613" width="375" height="20"/>
+                                                <rect key="frame" x="0.0" y="660" width="375" height="20"/>
                                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="X66-Es-mbY"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jHZ-sT-dDU">
-                                                <rect key="frame" x="0.0" y="633" width="375" height="50"/>
+                                                <rect key="frame" x="0.0" y="680" width="375" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WEBP" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K3X-6y-iEn">
                                                         <rect key="frame" x="15" y="0.0" width="345" height="48"/>
@@ -1223,7 +1263,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G09-UE-tFR">
-                                                <rect key="frame" x="0.0" y="683" width="375" height="47"/>
+                                                <rect key="frame" x="0.0" y="730" width="375" height="47"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="751" text="Method" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F8F-4Z-70B">
                                                         <rect key="frame" x="15" y="15" width="50" height="17"/>
@@ -1263,7 +1303,7 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BD3-n4-Odq">
-                                                <rect key="frame" x="0.0" y="730" width="375" height="47"/>
+                                                <rect key="frame" x="0.0" y="777" width="375" height="47"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="751" text="Image Hint" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R3y-mb-pf3">
                                                         <rect key="frame" x="15" y="15" width="70" height="17"/>
@@ -1333,6 +1373,7 @@
                         <outlet property="jpegUseProgressiveSwitch" destination="yi4-H9-VTq" id="Tyr-Rl-lLJ"/>
                         <outlet property="jpegUsePsnrQuantTableSwitch" destination="1wV-VG-cDB" id="NiL-zN-5Y5"/>
                         <outlet property="jpegUseTrellisSwitch" destination="F6F-kY-4eL" id="TBR-ZU-VkW"/>
+                        <outlet property="pngCompressionLevelButton" destination="Zsm-ha-2hY" id="thH-Qd-kxO"/>
                         <outlet property="pngUseInterlacingSwitch" destination="Dbu-yl-J0V" id="GfC-7P-9cO"/>
                         <outlet property="propagateChromaSamplingModeFromSourceSwitch" destination="7yo-uj-9L7" id="EW2-eW-Wmt"/>
                         <outlet property="webpImageHintButton" destination="m8p-Wj-Vkb" id="0me-1k-ggJ"/>

--- a/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewController.swift
+++ b/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewController.swift
@@ -37,6 +37,7 @@ final class ConfigurationViewController: UIViewController, ConfigurationViewMode
   @IBOutlet private var jpegUseDcScanOptionSwitch: UISwitch!
   @IBOutlet private var jpegUsePsnrQuantTableSwitch: UISwitch!
   @IBOutlet private var pngUseInterlacingSwitch: UISwitch!
+  @IBOutlet private var pngCompressionLevelButton: UIButton!
   @IBOutlet private var webpMethodButton: UIButton!
   @IBOutlet private var webpImageHintButton: UIButton!
 
@@ -80,6 +81,7 @@ final class ConfigurationViewController: UIViewController, ConfigurationViewMode
 
     self.alertOptionControllerByButton = [
       self.generalDefaultBackgroundColorButton: AnyAlertOptionController(alertContent: Alerts.configurationGeneralDefaultBackgroundColor, destination: viewModel.general, keyPath: \.defaultBackgroundColor),
+      self.pngCompressionLevelButton: AnyAlertOptionController(alertContent: Alerts.configurationPngCompressionLevel, destination: viewModel.png, keyPath: \.compressionLevel),
       self.webpMethodButton: AnyAlertOptionController(alertContent: Alerts.configurationWebpMethod, destination: viewModel.webp, keyPath: \.method),
       self.webpImageHintButton: AnyAlertOptionController(alertContent: Alerts.configurationWebpImageHint, destination: viewModel.webp, keyPath: \.imageHint),
     ]
@@ -108,7 +110,9 @@ final class ConfigurationViewController: UIViewController, ConfigurationViewMode
     self.jpegUseOptimizeScanSwitch.isOn = viewModel.jpeg.useOptimizeScan
     self.jpegUseDcScanOptionSwitch.isOn = viewModel.jpeg.useCompatibleDCScanOption
     self.jpegUsePsnrQuantTableSwitch.isOn = viewModel.jpeg.usePSNRQuantTable
+    
     self.pngUseInterlacingSwitch.isOn = viewModel.png.useInterlacing
+    self.pngCompressionLevelButton.setTitle(viewModel.png.compressionLevel.title, for: .normal)
 
     self.webpMethodButton.setTitle(viewModel.webp.method.title, for: .normal)
     self.webpImageHintButton.setTitle(viewModel.webp.imageHint.title, for: .normal)

--- a/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel+Options.swift
+++ b/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel+Options.swift
@@ -110,11 +110,11 @@ extension ConfigurationViewModel {
     
     init?(rawValue: Int) {
       switch rawValue {
-      case 0:
+      case PngCompressionLevelNone:
         self = .none
-      case 1:
+      case PngCompressionLevelBestSpeed:
         self = .bestSpeed
-      case 9:
+      case PngCompressionLevelBestCompression:
         self = .bestCompression
       default:
         self = .default

--- a/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel+Options.swift
+++ b/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel+Options.swift
@@ -124,16 +124,21 @@ extension ConfigurationViewModel {
     // MARK: AlertOptions
     
     var title: String {
+      let title: String
+      
       switch self {
       case .default:
-        return "Default"
+        return NSLocalizedString("Default", comment: "Png default compression level")
       case .none:
-        return "None (\(rawValue))"
+        title = NSLocalizedString("None", comment: "Png no compression level")
       case .bestSpeed:
-        return "Best speed (\(rawValue))"
+        title = NSLocalizedString("Best speed", comment: "Png best speed compression level")
       case .bestCompression:
-        return "Best compression (\(rawValue))"
+        title = NSLocalizedString("Best compression", comment: "Png best compression level")
       }
+      
+      let formatString = NSLocalizedString("%@ (%d)", comment: "Png compression level format String")
+      return String(format: formatString, title, rawValue)
     }
     
     var isAvailable: Bool {

--- a/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel+Options.swift
+++ b/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel+Options.swift
@@ -88,6 +88,61 @@ extension ConfigurationViewModel {
 
     static var allValues: [DefaultBackgroundColor] = [.black, .white, .blue, .red, .green]
   }
+    
+  enum CompressionLevel: Int, AlertOptions {
+    case `default`
+    case none
+    case bestSpeed
+    case bestCompression
+    
+    var rawValue: Int {
+      switch self {
+      case .default:
+        return PngCompressionLevelDefault
+      case .none:
+        return PngCompressionLevelNone
+      case .bestSpeed:
+        return PngCompressionLevelBestSpeed
+      case .bestCompression:
+        return PngCompressionLevelBestCompression
+      }
+    }
+    
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 0:
+        self = .none
+      case 1:
+        self = .bestSpeed
+      case 9:
+        self = .bestCompression
+      default:
+        self = .default
+      }
+    }
+    
+    // MARK: AlertOptions
+    
+    var title: String {
+      switch self {
+      case .default:
+        return "Default"
+      case .none:
+        return "None (\(rawValue))"
+      case .bestSpeed:
+        return "Best speed (\(rawValue))"
+      case .bestCompression:
+        return "Best compression (\(rawValue))"
+      }
+    }
+    
+    var isAvailable: Bool {
+      return true
+    }
+    
+    static var allValues: [CompressionLevel] = [.default, .none, .bestSpeed, .bestCompression]
+    
+  }
 
   enum WebpMethod: Int, AlertOptions {
     case one = 1

--- a/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel.swift
+++ b/ios/SpectrumKitSample/SpectrumKitSample-iOS/ConfigurationViewModel.swift
@@ -132,6 +132,14 @@ final class ConfigurationViewModel: ConfigurationViewModelInternalDelegate {
         self.delegate?.internalViewModelDidUpdate(self)
       }
     }
+    
+    var compressionLevel: CompressionLevel {
+      get { return CompressionLevel(rawValue: self.configuration.compressionLevel)! }
+      set {
+        self.configuration.compressionLevel = newValue.rawValue
+        self.delegate?.internalViewModelDidUpdate(self)
+      }
+    }
 
     // MARK: - Private Properties
 
@@ -141,7 +149,6 @@ final class ConfigurationViewModel: ConfigurationViewModelInternalDelegate {
 
     init(configuration: ConfigurationPng) {
       self.configuration = configuration
-      self.useInterlacing = configuration.useInterlacing
     }
   }
 


### PR DESCRIPTION
Solution for issue #2 

I'll be glad to hear your minds about the right place to put a predefined set of compression level constants for the Android wrapper. Will it be a good choice to define them right in the `Configuration` class?