### PR TITLE
Update libwebp to 1.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ jobs:
       - image: circleci/android:api-28-ndk-r17b
     steps:
       - checkout
+      - run: yes | sdkmanager --licenses || exit 0
+      - run: yes | sdkmanager --update || exit 0
       - run: ./gradlew prepareNative
       - run: ./gradlew assembleRelease
 
@@ -33,6 +35,8 @@ jobs:
       - image: circleci/android:api-28-ndk-r17b
     steps:
       - checkout
+      - run: yes | sdkmanager --licenses || exit 0
+      - run: yes | sdkmanager --update || exit 0
       - run: ./gradlew prepareNative
       - run: ./gradlew android:sample:assembleDebug
 

--- a/androidLibs/third-party/libwebp/build.gradle
+++ b/androidLibs/third-party/libwebp/build.gradle
@@ -21,12 +21,12 @@ apply plugin: SpectrumDownloadAndMergePlugin
 import org.apache.tools.ant.filters.ReplaceTokens
 
 downloadAndMergeNativeLibrary {
-  externalSourceUri 'https://github.com/webmproject/libwebp/archive/v1.0.0.tar.gz'
-  externalSourceInclude 'libwebp-1.0.0/**'
+  externalSourceUri 'https://github.com/webmproject/libwebp/archive/v1.0.2.tar.gz'
+  externalSourceInclude 'libwebp-1.0.2/**'
   overrideInclude '**'
   filesMatchingPattern '**'
   filesMatchingAction {
-      it.path = it.path - "libwebp-1.0.0"
+      it.path = it.path - "libwebp-1.0.2"
   }
   cacheRevision = 1
 }

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -35,6 +35,6 @@ The iOS wrapper is built in Objective-C++ and calls the C++ library directly. It
   - `SpectrumKit/`: Sources of the main target.
   - `SpectrumKitPlugins/`: Subfolders contain Objective-C bundled codecs.
   - `SpectrumKitTests/`: Wrapper's unit tests.
-  - `SpectrumKitIntrumentationTests/`: Wrapper's integration tests.
-  - `SpectrumKitIntrumentationTestsHelpers/`: Helpers for the integration tests.
+  - `SpectrumKitInstrumentationTests/`: Wrapper's integration tests.
+  - `SpectrumKitInstrumentationTestsHelpers/`: Helpers for the integration tests.
 - `ios/SpectrumKitSample/`: SpectrumKit's sample app.

--- a/ios/SpectrumKitSample/Podfile.lock
+++ b/ios/SpectrumKitSample/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
   - libpng (1.6.18)
-  - libwebp (1.0.0):
-    - libwebp/core (= 1.0.0)
-    - libwebp/dec (= 1.0.0)
-    - libwebp/demux (= 1.0.0)
-    - libwebp/dsp (= 1.0.0)
-    - libwebp/enc (= 1.0.0)
-    - libwebp/mux (= 1.0.0)
-    - libwebp/utils (= 1.0.0)
-    - libwebp/webp (= 1.0.0)
-  - libwebp/core (1.0.0):
+  - libwebp (1.0.2):
+    - libwebp/core (= 1.0.2)
+    - libwebp/dec (= 1.0.2)
+    - libwebp/demux (= 1.0.2)
+    - libwebp/dsp (= 1.0.2)
+    - libwebp/enc (= 1.0.2)
+    - libwebp/mux (= 1.0.2)
+    - libwebp/utils (= 1.0.2)
+    - libwebp/webp (= 1.0.2)
+  - libwebp/core (1.0.2):
     - libwebp/webp
-  - libwebp/dec (1.0.0):
+  - libwebp/dec (1.0.2):
     - libwebp/core
-  - libwebp/demux (1.0.0):
+  - libwebp/demux (1.0.2):
     - libwebp/core
-  - libwebp/dsp (1.0.0):
+  - libwebp/dsp (1.0.2):
     - libwebp/core
-  - libwebp/enc (1.0.0):
+  - libwebp/enc (1.0.2):
     - libwebp/core
-  - libwebp/mux (1.0.0):
+  - libwebp/mux (1.0.2):
     - libwebp/core
-  - libwebp/utils (1.0.0):
+  - libwebp/utils (1.0.2):
     - libwebp/core
-  - libwebp/webp (1.0.0)
+  - libwebp/webp (1.0.2)
   - mozjpeg (3.3.1)
   - spectrum-folly (2018.11.12.00)
   - SpectrumCore (1.0.0):

--- a/ios/SpectrumKitSample/Podfile.lock
+++ b/ios/SpectrumKitSample/Podfile.lock
@@ -88,7 +88,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libpng: 9c661ee692282485a9cf7fcf0159458c91b4f943
-  libwebp: d7e0c95fe97245c97e08101eba10702ebb0f6101
+  libwebp: b068a3bd7c45f7460f6715be7bed1a18fd5d6b48
   mozjpeg: a4d59753cccb0d7c2bcb38cd4eb936c72ec59234
   spectrum-folly: 0b143554b0263383ac75a85b2b22f1f056900d21
   SpectrumCore: dae3bb32c202578d6a88c50093eaeaf57acf3279


### PR DESCRIPTION
Update libwebp to 1.0.2. Contains some speedups and security fixes.

**iOS**
- [x] ios/SpectrumKitSample/Podfile.lock
  - [x] updated version-numbers
  - [x] updated checksum ~~(blocked by outdated [CocoaPod](https://cocoapods.org/pods/libwebp))~~

**Android**
- [x] androidLibs/third-party/libwebp/build.gradle

**libwebp changelog:**
```
- 1/14/2019: version 1.0.2
  This is a binary compatible release.
  * (Windows) unicode file support in the tools (linux and mac already had
    support, issue #398)
  * lossless encoder speedups
  * lossy encoder speedup on ARM
  * lossless multi-threaded security fix (chromium:917029)

- 11/2/2018: version 1.0.1
  This is a binary compatible release.
  * lossless encoder speedups
  * big-endian fix for alpha decoding (issue #393)
  * gif2webp fix for loop count=65535 transcode (issue #382)
  * further security related hardening in libwebp & libwebpmux
    (issues #383, #385, #386, #387, #388, #391)
    (oss-fuzz #9099, #9100, #9105, #9106, #9111, #9112, #9119, #9123, #9170,
              #9178, #9179, #9183, #9186, #9191, #9364, #9417, #9496, #10349,
              #10423, #10634, #10700, #10838, #10922, #11021, #11088, #11152)
  * miscellaneous bug & build fixes (issues #381, #394, #396, #397, #400)
```