### PR TITLE
Add manual license accept to CircleCI config (work-around); closes #19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ jobs:
       - image: circleci/android:api-28-ndk-r17b
     steps:
       - checkout
+      - run: yes | sdkmanager --licenses || exit 0
+      - run: yes | sdkmanager --update || exit 0
       - run: ./gradlew prepareNative
       - run: ./gradlew assembleRelease
 
@@ -33,6 +35,8 @@ jobs:
       - image: circleci/android:api-28-ndk-r17b
     steps:
       - checkout
+      - run: yes | sdkmanager --licenses || exit 0
+      - run: yes | sdkmanager --update || exit 0
       - run: ./gradlew prepareNative
       - run: ./gradlew android:sample:assembleDebug
 


### PR DESCRIPTION
Manual work-around to fix the CircleCI integration until new images have been deployed. See https://discuss.circleci.com/t/android-platform-28-sdk-license-not-accepted/27768 for background.