### PR TITLE
Set default compression level of PNG format to null to avoid the crash on Android sample app

### DIFF
--- a/android/sample/src/main/java/com/facebook/spectrum/sample/model/ConfigurationViewModel.kt
+++ b/android/sample/src/main/java/com/facebook/spectrum/sample/model/ConfigurationViewModel.kt
@@ -75,7 +75,8 @@ enum class ConfigurationViewModel {
     )
 
     private val pngCompressionLevel: Array<EnumParameterEntry<Int>> = arrayOf(
-            EnumParameterEntry("Default level = 0", "No compression", 0),
+            EnumParameterEntry("Default", null, null as Int?),
+            EnumParameterEntry("Compression level = 0", "No compression", 0),
             EnumParameterEntry("Compression level = 1", "Best speed", 1),
             EnumParameterEntry("Compression level = 9", "Best compression", 9)
     )
@@ -110,7 +111,7 @@ enum class ConfigurationViewModel {
             ),
             ParameterGroup("Png", arrayOf(
                     BooleanParameter("Save with interlacing", false) { cb, v -> cb.setUseInterlacing(v) },
-                    EnumParameter("Compression level", pngCompressionLevel) { cb, v -> cb.setCompressionLevel(v) })
+                    EnumParameter("Compression level", pngCompressionLevel) { cb, v -> v?.let { cb.setCompressionLevel(v) } })
             ),
             ParameterGroup("WebP", arrayOf(
                     EnumParameter("Webp compression method", webpMethodEntries) { cb, v -> v?.let { cb.setWebpMethod(it) } },

--- a/android/sample/src/main/java/com/facebook/spectrum/sample/model/ConfigurationViewModel.kt
+++ b/android/sample/src/main/java/com/facebook/spectrum/sample/model/ConfigurationViewModel.kt
@@ -75,8 +75,7 @@ enum class ConfigurationViewModel {
     )
 
     private val pngCompressionLevel: Array<EnumParameterEntry<Int>> = arrayOf(
-            EnumParameterEntry("Default", null, -1),
-            EnumParameterEntry("Compression level = 0", "No compression", 0),
+            EnumParameterEntry("Default level = 0", "No compression", 0),
             EnumParameterEntry("Compression level = 1", "Best speed", 1),
             EnumParameterEntry("Compression level = 9", "Best compression", 9)
     )


### PR DESCRIPTION
Related to this issue  https://github.com/facebookincubator/spectrum/issues/36
Fix the crash on Android sample app.
Reason for the crash was compression default parameter set by `-1`.