### PR TITLE
Improved CircleCI integration 🥳 running instrumentation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ commands:
       - run:
           name: Create emulator
           command: |
+            source ".circleci/scripts/.tests.env"
             AVD_PACKAGES="system-images;android-$ANDROID_SDK_TARGET_API_LEVEL;google_apis;$AVD_ABI"
             echo "Creating AVD with packages $AVD_PACKAGES"
             echo no | avdmanager create avd --name "$AVD_NAME" --force --package "$AVD_PACKAGES" --tag google_apis --abi "$AVD_ABI"
@@ -53,7 +54,15 @@ commands:
       - run:
           name: Launch emulator
           command: |
+            source ".circleci/scripts/.tests.env"
             "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" -no-audio -no-window
+  wait_for_emulator:
+    steps:
+      - run:
+          name: Wait for emulator
+          command: |
+            source ".circleci/scripts/.tests.env"
+            ".circleci/scripts/wait_for_emulator.sh"
 
 #
 # JOBS
@@ -94,6 +103,7 @@ jobs:
       - prepare_native_gradle_deps
       - create_emulator
       - launch_emulator
+      - wait_for_emulator
       - run: ./gradlew test
       - run: ./gradlew connectedAndroidTest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,8 @@ commands:
     steps:
       - run:
           name: Launch emulator
-          command: "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" -no-audio -no-window
+          command: |
+            "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" -no-audio -no-window
 
 #
 # JOBS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,50 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+#
+# GENERAL CONFIG
+#
+
+version: 2.1
+
 aliases:
  - &filter-only-master
    branches:
      only:
        - master
 
-version: 2
+defaults: &defaults
+  working_directory: ~/react-native
+  environment:
+    - GIT_COMMIT_DESC: git log --format=oneline -n 1 $CIRCLE_SHA1
+
+#
+# EXECUTORS & JOBS
+#
+
+executors:
+  spectrumandroid:
+    <<: *defaults
+    docker:
+      - image: reactnativecommunity/react-native-android:2019-5-29
+    resource_class: "large"
+    environment:
+      - TERM: "dumb"
+      - ADB_INSTALL_TIMEOUT: 10
+      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
+      - BUILD_THREADS: 2
+
+commands:
+    prepare_native_gradle_deps:
+      steps:
+        - run:
+          name: Download and prepare native dependencies via gralde
+          command: ./gradlew prepareNative
+
+#
+# JOBS
+#
+
 jobs:
   deploy-website:
     docker:
@@ -20,25 +58,24 @@ jobs:
             git config --global user.name "Website Deployment Script"
             echo "machine github.com login docusaurus-bot password $GITHUB_DOCUSAURUS_TOKEN" > ~/.netrc
             cd website && yarn install && GIT_USER=docusaurus-bot USE_SSH=false yarn run publish-gh-pages
+
   build-android-release:
-    docker:
-      - image: circleci/android:api-28-ndk-r17b
+    executor: spectrumandroid
     steps:
       - checkout
-      - run: yes | sdkmanager --licenses || exit 0
-      - run: yes | sdkmanager --update || exit 0
-      - run: ./gradlew prepareNative
+      - prepare_native_gradle_deps
       - run: ./gradlew assembleRelease
 
   build-android-sample-app:
-    docker:
-      - image: circleci/android:api-28-ndk-r17b
+    executor: spectrumandroid
     steps:
       - checkout
-      - run: yes | sdkmanager --licenses || exit 0
-      - run: yes | sdkmanager --update || exit 0
-      - run: ./gradlew prepareNative
+      - prepare_native_gradle_deps
       - run: ./gradlew android:sample:assembleDebug
+
+#
+# WORKFLOWS
+#
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,4 +115,4 @@ workflows:
           filters: *filter-only-master
       - build-android-release
       - build-android-sample-app
-      - build-android-sample-app
+      - test-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ commands:
     steps:
       - run:
           name: Launch emulator
+          background: true
           command: |
             source ".circleci/scripts/.tests.env"
             "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" -no-audio -no-window
@@ -100,11 +101,17 @@ jobs:
     executor: spectrumandroid
     steps:
       - checkout
-      - prepare_native_gradle_deps
       - create_emulator
       - launch_emulator
-      - wait_for_emulator
+
+      # continue with unit tests while we wait for the emulator
+      - prepare_native_gradle_deps
       - run: ./gradlew test
+
+      # pre-build some artifacts while we are waiting
+      - run: ./gradlew assembleDebug
+
+      - wait_for_emulator
       - run: ./gradlew connectedAndroidTest
 
 #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,20 +12,15 @@ aliases:
      only:
        - master
 
-defaults: &defaults
-  working_directory: ~/react-native
-  environment:
-    - GIT_COMMIT_DESC: git log --format=oneline -n 1 $CIRCLE_SHA1
-
 #
 # EXECUTORS & JOBS
 #
 
 executors:
   spectrumandroid:
-    <<: *defaults
     docker:
       - image: reactnativecommunity/react-native-android:2019-5-29
+    working_directory: ~/react-native
     resource_class: "large"
     environment:
       - TERM: "dumb"
@@ -38,7 +33,7 @@ commands:
   prepare_native_gradle_deps:
     steps:
       - run:
-          name: Download and prepare native dependencies via gralde
+          name: Download and prepare native dependencies via Gradle
           command: ./gradlew prepareNative
   create_emulator:
     steps:
@@ -104,12 +99,9 @@ jobs:
       - create_emulator
       - launch_emulator
 
-      # continue with unit tests while we wait for the emulator
+      # continue with unit tests while we wait for the emulator to have launched
       - prepare_native_gradle_deps
       - run: ./gradlew test
-
-      # pre-build some artifacts while we are waiting
-      - run: ./gradlew assembleDebug
 
       - wait_for_emulator
       - run: ./gradlew connectedAndroidTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,6 @@ executors:
       - BUILD_THREADS: 2
 
 commands:
-  install_apt_get_deps:
-    steps:
-      - run:
-          name: Download apt-get build dependencies
-          command: sudo apt-get install ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6 make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev libpulse0 file -y
   prepare_native_gradle_deps:
     steps:
       - run:
@@ -96,7 +91,6 @@ jobs:
     executor: spectrumandroid
     steps:
       - checkout
-      - install_apt_get_deps
       - prepare_native_gradle_deps
       - create_emulator
       - launch_emulator

--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -3,6 +3,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+#
+# Extracted from https://github.com/facebook/react-native/blob/master/scripts/.tests.env
 
 ## ANDROID ##
 # Android SDK Build Tools revision

--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -18,11 +18,6 @@ export AVD_NAME="testAVD"
 # ABI to use in Android Virtual Device
 export AVD_ABI=x86
 
-## IOS ##
-export IOS_TARGET_OS="12.2"
-export IOS_DEVICE="iPhone 6s"
-export TVOS_DEVICE="Apple TV"
-
 ## CI OVERRIDES ##
 # Values to override when running in CI
 # $CI is set by Circle CI

--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+## ANDROID ##
+# Android SDK Build Tools revision
+export ANDROID_SDK_BUILD_TOOLS_REVISION=28.0.3
+# Android API Level we build with
+export ANDROID_SDK_BUILD_API_LEVEL="28"
+# Google APIs for Android level
+export ANDROID_GOOGLE_API_LEVEL="23"
+# Minimum Android API Level we target
+export ANDROID_SDK_TARGET_API_LEVEL="19"
+# Android Virtual Device name
+export AVD_NAME="testAVD"
+# ABI to use in Android Virtual Device
+export AVD_ABI=x86
+
+## IOS ##
+export IOS_TARGET_OS="12.2"
+export IOS_DEVICE="iPhone 6s"
+export TVOS_DEVICE="Apple TV"
+
+## CI OVERRIDES ##
+# Values to override when running in CI
+# $CI is set by Circle CI
+if [ $CI ]; then
+  # Use ARM on Circle CI
+  export AVD_ABI=armeabi-v7a
+fi

--- a/.circleci/scripts/wait_for_emulator.sh
+++ b/.circleci/scripts/wait_for_emulator.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/.circleci/scripts/wait_for_emulator.sh
+++ b/.circleci/scripts/wait_for_emulator.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+echo "Waiting for Android Virtual Device to finish booting..."
+local bootanim=""
+export PATH=$(dirname $(dirname $(command -v android)))/platform-tools:$PATH
+until [[ "$bootanim" =~ "stopped" ]]; do
+  sleep 5
+  bootanim=$(adb -e shell getprop init.svc.bootanim 2>&1)
+  echo "boot animation status=$bootanim"
+done
+echo "Android Virtual Device is ready."

--- a/.circleci/scripts/wait_for_emulator.sh
+++ b/.circleci/scripts/wait_for_emulator.sh
@@ -3,9 +3,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+#
+# Extracted from https://github.com/facebook/react-native/blob/master/scripts/android-setup.sh
 
 echo "Waiting for Android Virtual Device to finish booting..."
-local bootanim=""
+bootanim=""
 export PATH=$(dirname $(dirname $(command -v android)))/platform-tools:$PATH
 until [[ "$bootanim" =~ "stopped" ]]; do
   sleep 5


### PR DESCRIPTION
This is based on parts of the React Native CircleCI integration. It uses
 - Their docker file (pinned to one version)
 - Their SDK/NDK choice (set through env variables)
 - Some of their logic regarding emulator handling

Testplan:
The CircleCI integration is happy and executed the instrumentation tests: https://circleci.com/gh/facebookincubator/spectrum/294

circle_of_life