### PR TITLE
Expose SoLoaderWrapper interface as public

### DIFF
--- a/android/src/main/java/com/facebook/spectrum/SpectrumSoLoader.java
+++ b/android/src/main/java/com/facebook/spectrum/SpectrumSoLoader.java
@@ -72,7 +72,7 @@ public class SpectrumSoLoader {
     sSoLoaderDelegate.loadLibrary(shortName);
   }
 
-  interface SoLoaderWrapper {
+  public interface SoLoaderWrapper {
     void init(final Context context);
 
     void loadLibrary(final String shortName);


### PR DESCRIPTION
As from discussion in #43 

This PR fixes issue when Kotlin generated code adds typecast to `SoLoaderWrapper` and this causes `IllegalAccessError` at run time as classes can't access package private `SoLoaderWrapper` interface.

**Kotlin:**
```
SpectrumSoLoader.init(context, SpectrumSoLoader.SystemSoLoaderImpl())
```

**Generated:**
```
SpectrumSoLoader.init((Context)context, (SoLoaderWrapper)(new SystemSoLoaderImpl()));
```

**Run-time error:**
```
java.lang.IllegalAccessError: Illegal class access: 'com.example.SpectrumLoader' attempting to access 'com.facebook.spectrum.SpectrumSoLoader$SoLoaderWrapper' (declaration of 'com.example.SpectrumLoader' appears in /data/app/com.example.dev-ZTjIGlrpJnf4A8NSyFKk4g==/split_lib_slice_2_apk.apk)
```