### PR TITLE
Fix accepted range in SpectrumLogcatLogger

### DIFF
--- a/android/src/main/java/com/facebook/spectrum/logging/SpectrumLogcatLogger.java
+++ b/android/src/main/java/com/facebook/spectrum/logging/SpectrumLogcatLogger.java
@@ -90,6 +90,6 @@ public class SpectrumLogcatLogger extends BaseSpectrumLogger {
   }
 
   private static boolean isValidLogLevel(final int level) {
-    return level >= Log.DEBUG && level <= Log.ASSERT;
+    return level >= Log.VERBOSE && level <= Log.ASSERT;
   }
 }

--- a/android/src/test/java/com/facebook/spectrum/SpectrumLogcatLoggerTest.java
+++ b/android/src/test/java/com/facebook/spectrum/SpectrumLogcatLoggerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.spectrum;
+
+import android.util.Log;
+
+import com.facebook.spectrum.logging.SpectrumLogcatLogger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class SpectrumLogcatLoggerTest {
+
+    private static final int[] VALID_LOGCAT_LEVELS = new int[]{
+        Log.VERBOSE, // = 2
+        Log.DEBUG, // = 3
+        Log.INFO, // = 4
+        Log.WARN, // = 5
+        Log.ERROR, // = 6
+        Log.ASSERT   // = 7
+    };
+
+    @Test
+    public void testLogcatLogger_whenValidLevel_thenConstructionSucceeds() {
+        for(int level : VALID_LOGCAT_LEVELS) {
+            new SpectrumLogcatLogger(level);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLogcatLogger_whenLevelBelowValid_thenThrow() {
+        new SpectrumLogcatLogger(1); // lowest valid level is 2
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLogcatLogger_whenLevelAboveValid_thenThrow() {
+        new SpectrumLogcatLogger(8); // highest valid level is 7
+    }
+}


### PR DESCRIPTION
The previous implementation assumed that `DEBUG` is the lowest level. However, `VERBOSE` is the lowest level and the new implementation correctly accepts it.

Comes with unit tests - of course

Closes #180 