### PR TITLE
Dependencies: Update libwebp, Folly, Android API

### DIFF
--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -8,9 +8,9 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=29.0.1
+export ANDROID_SDK_BUILD_TOOLS_REVISION=29.0.3
 # Android API Level we build with
-export ANDROID_SDK_BUILD_API_LEVEL="28"
+export ANDROID_SDK_BUILD_API_LEVEL="29"
 # Google APIs for Android level
 export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API Level we target

--- a/Specs/folly/spectrum-folly.podspec
+++ b/Specs/folly/spectrum-folly.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "spectrum-folly"
-  spec.version = "2019.01.21.00"
+  spec.version = "2020.02.03.00"
   spec.license = { :type => "Apache License, Version 2.0" }
   spec.homepage = "https://github.com/facebook/folly"
   spec.summary = "An open-source C++ library developed and used at Facebook."

--- a/SpectrumCore.podspec
+++ b/SpectrumCore.podspec
@@ -21,7 +21,7 @@ Spectrum is a cross-platform image transcoding library that can easily be integr
                           'Plugins/Png',
                           'Plugins/Webp'
 
-  spec.dependency 'spectrum-folly', '~> 2019.01.21.00'
+  spec.dependency 'spectrum-folly', '~> 2020.02.03.00'
   spec.compiler_flags = compiler_flags
 
   spec.subspec 'Base' do |base_spec|

--- a/SpectrumCore.podspec
+++ b/SpectrumCore.podspec
@@ -50,7 +50,7 @@ Spectrum is a cross-platform image transcoding library that can easily be integr
 
     plugins_spec.subspec 'Webp' do |plugins_webp_spec|
       plugins_webp_spec.dependency 'SpectrumCore/Base', version
-      plugins_webp_spec.dependency 'libwebp', '~> 1.0.2'
+      plugins_webp_spec.dependency 'libwebp', '~> 1.1.0'
       plugins_webp_spec.source_files = 'cpp/spectrum/plugins/webp/**/*.{h,cpp}'
       plugins_webp_spec.header_dir = 'spectrum/plugins/webp'
       plugins_webp_spec.header_mappings_dir = 'cpp/spectrum/plugins/webp'

--- a/SpectrumKit.podspec
+++ b/SpectrumKit.podspec
@@ -18,7 +18,7 @@ Spectrum is a cross-platform image transcoding library that can easily be integr
   spec.source = { :git => 'https://github.com/facebookincubator/spectrum.git', :tag => "v#{version}" }
   spec.ios.deployment_target = '8.0'
   spec.default_subspecs = 'Plugins/Default'
-  spec.dependency 'spectrum-folly', '~> 2019.01.21.00'
+  spec.dependency 'spectrum-folly', '~> 2020.02.03.00'
   spec.compiler_flags = compiler_flags
 
   spec.subspec 'Base' do |base_spec|

--- a/androidLibs/third-party/folly/build.gradle
+++ b/androidLibs/third-party/folly/build.gradle
@@ -25,12 +25,12 @@ android {
 apply plugin: SpectrumDownloadAndMergePlugin
 
 downloadAndMergeNativeLibrary {
-  externalSourceUri 'https://github.com/facebook/folly/archive/v2019.01.21.00.tar.gz'
-  externalSourceInclude 'folly-2019.01.21.00/**'
+  externalSourceUri 'https://github.com/facebook/folly/archive/v2020.02.03.00.tar.gz'
+  externalSourceInclude 'folly-2020.02.03.00/**'
   overrideInclude '**'
   filesMatchingPattern '**'
   filesMatchingAction {
-      it.path = it.path - "folly-2019.01.21.00/"
+      it.path = it.path - "folly-2020.02.03.00/"
   }
   cacheRevision = 1
 }

--- a/androidLibs/third-party/libwebp/build.gradle
+++ b/androidLibs/third-party/libwebp/build.gradle
@@ -21,12 +21,12 @@ apply plugin: SpectrumDownloadAndMergePlugin
 import org.apache.tools.ant.filters.ReplaceTokens
 
 downloadAndMergeNativeLibrary {
-  externalSourceUri 'https://github.com/webmproject/libwebp/archive/v1.0.2.tar.gz'
-  externalSourceInclude 'libwebp-1.0.2/**'
+  externalSourceUri 'https://github.com/webmproject/libwebp/archive/v1.1.0.tar.gz'
+  externalSourceInclude 'libwebp-1.1.0/**'
   overrideInclude '**'
   filesMatchingPattern '**'
   filesMatchingAction {
-      it.path = it.path - "libwebp-1.0.2"
+      it.path = it.path - "libwebp-1.1.0"
   }
   cacheRevision = 1
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,25 +47,25 @@ ext.isRelease = { ['uploadArchives', 'bintrayUpload'].any { gradle.startParamete
 ext.deps = [
         // Android Support Libraries
         supportAppCompat: 'androidx.appcompat:appcompat:1.0.0',
-        supportTestRunner: 'androidx.test:runner:1.1.0',
-        supportTestRules: 'androidx.test:rules:1.1.0',
+        supportTestRunner: 'androidx.test:runner:1.2.0',
+        supportTestRules: 'androidx.test:rules:1.2.0',
         supportMultidex: 'androidx.multidex:multidex:2.0.1',
 
         // Annotations
-        jsr305: 'com.google.code.findbugs:jsr305:3.0.1',
+        jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
 
         // First-party
-        soloader: 'com.facebook.soloader:soloader:0.6.1',
+        soloader: 'com.facebook.soloader:soloader:0.9.0',
 
         // Third-party
         dexmaker: 'com.google.dexmaker:dexmaker:1.2',
         dexmakerMockito: 'com.google.dexmaker:dexmaker-mockito:1.2',
         festAssert: 'org.easytesting:fest-assert-core:2.0M10',
         junit: 'junit:junit:4.12',
-        kotlinAndroidKtx: 'androidx.core:core-ktx:1.0.1',
+        kotlinAndroidKtx: 'androidx.core:core-ktx:1.2.0',
         kotlinJdk: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",
         mockitoCore: 'org.mockito:mockito-core:1.10.19',
-        robolectric: 'org.robolectric:robolectric:3.0',
+        robolectric: 'org.robolectric:robolectric:3.8',
 ]
 
 //

--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,10 @@
 buildscript {
     ext {
         minSdkVersion = 15
-        targetSdkVersion = 28
-        compileSdkVersion = 28
-        kotlinVersion = '1.3.41'
-        buildToolsVersion = '29.0.1'
+        targetSdkVersion = 29
+        compileSdkVersion = 29
+        kotlinVersion = '1.3.72'
+        buildToolsVersion = '29.0.3'
         sourceCompatibilityVersion = JavaVersion.VERSION_1_7
         targetCompatibilityVersion = JavaVersion.VERSION_1_7
     }

--- a/ios/SpectrumKitSample/Podfile.lock
+++ b/ios/SpectrumKitSample/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
   - libpng (1.6.35)
-  - libwebp (1.0.2):
-    - libwebp/core (= 1.0.2)
-    - libwebp/dec (= 1.0.2)
-    - libwebp/demux (= 1.0.2)
-    - libwebp/dsp (= 1.0.2)
-    - libwebp/enc (= 1.0.2)
-    - libwebp/mux (= 1.0.2)
-    - libwebp/utils (= 1.0.2)
-    - libwebp/webp (= 1.0.2)
-  - libwebp/core (1.0.2):
+  - libwebp (1.1.0):
+    - libwebp/core (= 1.1.0)
+    - libwebp/dec (= 1.1.0)
+    - libwebp/demux (= 1.1.0)
+    - libwebp/dsp (= 1.1.0)
+    - libwebp/enc (= 1.1.0)
+    - libwebp/mux (= 1.1.0)
+    - libwebp/utils (= 1.1.0)
+    - libwebp/webp (= 1.1.0)
+  - libwebp/core (1.1.0):
     - libwebp/webp
-  - libwebp/dec (1.0.2):
+  - libwebp/dec (1.1.0):
     - libwebp/core
-  - libwebp/demux (1.0.2):
+  - libwebp/demux (1.1.0):
     - libwebp/core
-  - libwebp/dsp (1.0.2):
+  - libwebp/dsp (1.1.0):
     - libwebp/core
-  - libwebp/enc (1.0.2):
+  - libwebp/enc (1.1.0):
     - libwebp/core
-  - libwebp/mux (1.0.2):
+  - libwebp/mux (1.1.0):
     - libwebp/core
-  - libwebp/utils (1.0.2):
+  - libwebp/utils (1.1.0):
     - libwebp/core
-  - libwebp/webp (1.0.2)
+  - libwebp/webp (1.1.0)
   - mozjpeg (3.3.2)
   - spectrum-folly (2019.01.21.00)
   - SpectrumCore (1.1.0):
@@ -42,7 +42,7 @@ PODS:
     - spectrum-folly (~> 2019.01.21.00)
     - SpectrumCore/Base (= 1.1.0)
   - SpectrumCore/Plugins/Webp (1.1.0):
-    - libwebp (~> 1.0.2)
+    - libwebp (~> 1.1.0)
     - spectrum-folly (~> 2019.01.21.00)
     - SpectrumCore/Base (= 1.1.0)
   - SpectrumKit (1.1.0):

--- a/ios/SpectrumKitSample/Podfile.lock
+++ b/ios/SpectrumKitSample/Podfile.lock
@@ -25,47 +25,47 @@ PODS:
     - libwebp/core
   - libwebp/webp (1.1.0)
   - mozjpeg (3.3.2)
-  - spectrum-folly (2019.01.21.00)
+  - spectrum-folly (2020.02.03.00)
   - SpectrumCore (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Plugins/Jpeg (= 1.1.0)
     - SpectrumCore/Plugins/Png (= 1.1.0)
     - SpectrumCore/Plugins/Webp (= 1.1.0)
   - SpectrumCore/Base (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
   - SpectrumCore/Plugins/Jpeg (1.1.0):
     - mozjpeg (= 3.3.2)
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Base (= 1.1.0)
   - SpectrumCore/Plugins/Png (1.1.0):
     - libpng (~> 1.6.35)
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Base (= 1.1.0)
   - SpectrumCore/Plugins/Webp (1.1.0):
     - libwebp (~> 1.1.0)
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Base (= 1.1.0)
   - SpectrumKit (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumKit/Plugins/Default (= 1.1.0)
   - SpectrumKit/Base (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Base
   - SpectrumKit/Plugins/Default (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumKit/Plugins/Jpeg (= 1.1.0)
     - SpectrumKit/Plugins/Png (= 1.1.0)
     - SpectrumKit/Plugins/Webp (= 1.1.0)
   - SpectrumKit/Plugins/Jpeg (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Plugins/Jpeg
     - SpectrumKit/Base (= 1.1.0)
   - SpectrumKit/Plugins/Png (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Plugins/Png (= 1.1.0)
     - SpectrumKit/Base (= 1.1.0)
   - SpectrumKit/Plugins/Webp (1.1.0):
-    - spectrum-folly (~> 2019.01.21.00)
+    - spectrum-folly (~> 2020.02.03.00)
     - SpectrumCore/Plugins/Webp (= 1.1.0)
     - SpectrumKit/Base (= 1.1.0)
 


### PR DESCRIPTION
Dependency update.
- Updates libwebp from v1.0.2 to v1.1.0 (succeeds #18)
- Updates Folly from v2019.01.21 to v2020.02.03 (succeeds #20)
   -  -  [ ] the [spectrum-folly CocoaPod](https://cocoapods.org/pods/spectrum-folly) needs to be updated
- Updates Android API level in CI to 29 (Android 10)
