### PR TITLE
Fix ScalingScanlineProcessingBlock memory leaks

### DIFF
--- a/cpp/spectrum/core/proc/ScalingScanlineProcessingBlock.cpp
+++ b/cpp/spectrum/core/proc/ScalingScanlineProcessingBlock.cpp
@@ -141,7 +141,7 @@ void MagicKernelScalingBlockImpl::runMagicKernel() {
     }
 
     // free processed input
-    input[nextLineToRelease].release();
+    input[nextLineToRelease].reset();
     nextLineToRelease++;
   }
 }
@@ -321,7 +321,7 @@ std::unique_ptr<image::Scanline> BicubicScalingBlockImpl::produce() {
   // free scanlines that will not be touched again
   for (int i = nextLineToRelease; i < y0; i++) {
     SPECTRUM_ENFORCE_IF(input[i] == nullptr);
-    input[i].release();
+    input[i].reset();
   }
   nextLineToRelease = y0;
 

--- a/cpp/spectrum/core/proc/ScanlinePump.cpp
+++ b/cpp/spectrum/core/proc/ScanlinePump.cpp
@@ -23,7 +23,7 @@ void ScanlinePump::pumpAll() {
     auto scanline = scanlineGenerator();
     SPECTRUM_ENFORCE_IF_NOT(scanline);
 
-    // exectue processing blocks and consumer while there's actual processing
+    // execute processing blocks and consumer while there's actual processing
     // happening in any of the processing steps
     bool change;
     do {


### PR DESCRIPTION
This fixes #196 

I noticed that every time scaling is used, the library leaks a significant amount of native heap memory (tested on Android). I traced the problem to `ScalingScanlineProcessingBlock` module, where the `Scanline` objects were not correctly freed for each processed input scanline.

I verified this fix on Android only, since the changes are quite trivial.