### PR TITLE
build.gradle: Update androidx.multidex from 2.0.0 to 2.0.1

### DIFF
--- a/android/spectrumtests/build.gradle
+++ b/android/spectrumtests/build.gradle
@@ -15,6 +15,7 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     sourceSets {
@@ -30,6 +31,7 @@ android {
 dependencies {
     compileOnly deps.jsr305
     implementation deps.soloader
+    implementation 'androidx.multidex:multidex:2.0.1'
     androidTestImplementation project(':android:spectrumdefault')
     androidTestImplementation project(':android:spectrumpluginplatform')
     androidTestImplementation project(':android:spectrumtestutils')

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ ext.deps = [
         supportAppCompat: 'androidx.appcompat:appcompat:1.0.0',
         supportTestRunner: 'androidx.test:runner:1.1.0',
         supportTestRules: 'androidx.test:rules:1.1.0',
-        supportMultidex: 'androidx.multidex:multidex:2.0.0',
+        supportMultidex: 'androidx.multidex:multidex:2.0.1',
 
         // Annotations
         jsr305: 'com.google.code.findbugs:jsr305:3.0.1',


### PR DESCRIPTION
@diegosanchezr This could help solve #200, since the Multidex [changelog](https://developer.android.com/jetpack/androidx/releases/multidex#2.0.1) contains a line regarding Robolectric testing.

> **Bug fixes**
> - Fixed compatibility with Robolectric testing. Improved performance of version checking code.