### PR TITLE
Optimize build and fix CI task

### DIFF
--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -27,7 +27,6 @@ android {
     buildTypes {
         release {
             minifyEnabled true
-            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),'proguard-rules.pro'
         }
     }

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -27,7 +27,8 @@ android {
     buildTypes {
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt')
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),'proguard-rules.pro'
         }
     }
 }

--- a/android/spectrumtests/build.gradle
+++ b/android/spectrumtests/build.gradle
@@ -18,6 +18,14 @@ android {
         multiDexEnabled true
     }
 
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),'proguard-rules.pro'
+        }
+    }
+
     sourceSets {
         androidTest {
             java {

--- a/android/spectrumtests/build.gradle
+++ b/android/spectrumtests/build.gradle
@@ -21,7 +21,6 @@ android {
     buildTypes {
         release {
             minifyEnabled true
-            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),'proguard-rules.pro'
         }
     }

--- a/android/spectrumtests/build.gradle
+++ b/android/spectrumtests/build.gradle
@@ -40,7 +40,7 @@ android {
 dependencies {
     compileOnly deps.jsr305
     implementation deps.soloader
-    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation deps.supportMultidex
     androidTestImplementation project(':android:spectrumdefault')
     androidTestImplementation project(':android:spectrumpluginplatform')
     androidTestImplementation project(':android:spectrumtestutils')

--- a/android/spectrumtests/build.gradle
+++ b/android/spectrumtests/build.gradle
@@ -10,6 +10,8 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
+    testOptions.unitTests.includeAndroidResources = true
+
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion

--- a/android/spectrumtests/build.gradle
+++ b/android/spectrumtests/build.gradle
@@ -15,6 +15,7 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     sourceSets {
@@ -30,6 +31,7 @@ android {
 dependencies {
     compileOnly deps.jsr305
     implementation deps.soloader
+    implementation 'androidx.multidex:multidex:2.0.1'
     androidTestImplementation project(':android:spectrumdefault')
     androidTestImplementation project(':android:spectrumpluginplatform')
     androidTestImplementation project(':android:spectrumtestutils')

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ ext.deps = [
         supportAppCompat: 'androidx.appcompat:appcompat:1.0.0',
         supportTestRunner: 'androidx.test:runner:1.1.0',
         supportTestRules: 'androidx.test:rules:1.1.0',
-        supportMultidex: 'androidx.multidex:multidex:2.0.0',
+        supportMultidex: 'androidx.multidex:multidex:2.0.1',
 
         // Annotations
         jsr305: 'com.google.code.findbugs:jsr305:3.0.1',


### PR DESCRIPTION
On the master branch, `Task :android:spectrumtests:mergeDexDebugAndroidTest` fails in the `circleci: test-android` job. This PR resolves that issue by minifing and enabling multidex in the spectrumtest.

The job still fails, but a lot further at `Task :android:spectrumtests:connectedDebugAndroidTest FAILED`

@diegosanchezr Please review.

Please squash when merging.