### PR TITLE
Fixes some CI issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
     resource_class: "large"
     environment:
       - TERM: "dumb"
-      - ADB_INSTALL_TIMEOUT: 40
+      - ADB_INSTALL_TIMEOUT: 20
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       - BUILD_THREADS: 2
@@ -100,15 +100,16 @@ jobs:
       - checkout
       - create_emulator
       - launch_emulator
+      # wait for emulator to give it more time to finish startup activities before tests
+      - wait_for_emulator
 
-      # continue with unit tests while we wait for the emulator to have launched
+      # run unit tests
       - prepare_native_gradle_deps
       - run: ./gradlew test
 
-      - wait_for_emulator
       - run:
           command: ./gradlew connectedAndroidTest
-          no_output_timeout: 40m
+          no_output_timeout: 20m
 
 #
 # WORKFLOWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,9 @@ jobs:
       - run: ./gradlew test
 
       - wait_for_emulator
-      - run: ./gradlew connectedAndroidTest
+      - run:
+          command: ./gradlew connectedAndroidTest
+          no_output_timeout: 20m
 
 #
 # WORKFLOWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ aliases:
 executors:
   spectrumandroid:
     docker:
-      - image: reactnativecommunity/react-native-android:2019-5-29
+      - image: reactnativecommunity/react-native-android:2020-4-1
     working_directory: ~/react-native
     resource_class: "large"
     environment:
@@ -42,6 +42,8 @@ commands:
           command: |
             source ".circleci/scripts/.tests.env"
             AVD_PACKAGES="system-images;android-$ANDROID_SDK_TARGET_API_LEVEL;google_apis;$AVD_ABI"
+            echo "Installing syste image for $AVD_PACKAGES"
+            sdkmanager $AVD_PACKAGES
             echo "Creating AVD with packages $AVD_PACKAGES"
             echo no | avdmanager create avd --name "$AVD_NAME" --force --package "$AVD_PACKAGES" --tag google_apis --abi "$AVD_ABI"
   launch_emulator:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
     resource_class: "large"
     environment:
       - TERM: "dumb"
-      - ADB_INSTALL_TIMEOUT: 20
+      - ADB_INSTALL_TIMEOUT: 40
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       - BUILD_THREADS: 2
@@ -108,7 +108,7 @@ jobs:
       - wait_for_emulator
       - run:
           command: ./gradlew connectedAndroidTest
-          no_output_timeout: 20m
+          no_output_timeout: 40m
 
 #
 # WORKFLOWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
     resource_class: "large"
     environment:
       - TERM: "dumb"
-      - ADB_INSTALL_TIMEOUT: 10
+      - ADB_INSTALL_TIMEOUT: 20
       - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"'
       - BUILD_THREADS: 2

--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -14,7 +14,7 @@ export ANDROID_SDK_BUILD_API_LEVEL="28"
 # Google APIs for Android level
 export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API Level we target
-export ANDROID_SDK_TARGET_API_LEVEL="19"
+export ANDROID_SDK_TARGET_API_LEVEL="25"
 # Android Virtual Device name
 export AVD_NAME="testAVD"
 # ABI to use in Android Virtual Device

--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -14,7 +14,7 @@ export ANDROID_SDK_BUILD_API_LEVEL="28"
 # Google APIs for Android level
 export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API Level we target
-export ANDROID_SDK_TARGET_API_LEVEL="22"
+export ANDROID_SDK_TARGET_API_LEVEL="23"
 # Android Virtual Device name
 export AVD_NAME="testAVD"
 # ABI to use in Android Virtual Device

--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -14,7 +14,7 @@ export ANDROID_SDK_BUILD_API_LEVEL="28"
 # Google APIs for Android level
 export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API Level we target
-export ANDROID_SDK_TARGET_API_LEVEL="25"
+export ANDROID_SDK_TARGET_API_LEVEL="23"
 # Android Virtual Device name
 export AVD_NAME="testAVD"
 # ABI to use in Android Virtual Device

--- a/.circleci/scripts/.tests.env
+++ b/.circleci/scripts/.tests.env
@@ -14,7 +14,7 @@ export ANDROID_SDK_BUILD_API_LEVEL="28"
 # Google APIs for Android level
 export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API Level we target
-export ANDROID_SDK_TARGET_API_LEVEL="23"
+export ANDROID_SDK_TARGET_API_LEVEL="22"
 # Android Virtual Device name
 export AVD_NAME="testAVD"
 # ABI to use in Android Virtual Device

--- a/android/spectrumtestutils/build.gradle
+++ b/android/spectrumtestutils/build.gradle
@@ -15,6 +15,7 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
 
         ndk {
             abiFilters 'x86', 'armeabi-v7a', 'x86_64', 'arm64-v8a'


### PR DESCRIPTION
Bumping ANDROID_SDK_TARGET_API_LEVEL to v23 to solve the "No tests founds issue" and fixing a multidex missing configuration. 

Increased timeout and move wait for emulator step higher up, so it has more time to get idle.

This is sill resulting in flaky connectedAndroidTest due to poor emulator performance though.