### PR TITLE
Deps: Update to libwebp 1.1.0

### DIFF
--- a/SpectrumCore.podspec
+++ b/SpectrumCore.podspec
@@ -50,7 +50,7 @@ Spectrum is a cross-platform image transcoding library that can easily be integr
 
     plugins_spec.subspec 'Webp' do |plugins_webp_spec|
       plugins_webp_spec.dependency 'SpectrumCore/Base', version
-      plugins_webp_spec.dependency 'libwebp', '~> 1.0.2'
+      plugins_webp_spec.dependency 'libwebp', '~> 1.1.0'
       plugins_webp_spec.source_files = 'cpp/spectrum/plugins/webp/**/*.{h,cpp}'
       plugins_webp_spec.header_dir = 'spectrum/plugins/webp'
       plugins_webp_spec.header_mappings_dir = 'cpp/spectrum/plugins/webp'

--- a/androidLibs/third-party/libwebp/build.gradle
+++ b/androidLibs/third-party/libwebp/build.gradle
@@ -21,12 +21,12 @@ apply plugin: SpectrumDownloadAndMergePlugin
 import org.apache.tools.ant.filters.ReplaceTokens
 
 downloadAndMergeNativeLibrary {
-  externalSourceUri 'https://github.com/webmproject/libwebp/archive/v1.0.2.tar.gz'
-  externalSourceInclude 'libwebp-1.0.2/**'
+  externalSourceUri 'https://github.com/webmproject/libwebp/archive/v1.1.0.tar.gz'
+  externalSourceInclude 'libwebp-1.1.0/**'
   overrideInclude '**'
   filesMatchingPattern '**'
   filesMatchingAction {
-      it.path = it.path - "libwebp-1.0.2"
+      it.path = it.path - "libwebp-1.1.0"
   }
   cacheRevision = 1
 }

--- a/ios/SpectrumKitSample/Podfile.lock
+++ b/ios/SpectrumKitSample/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
   - libpng (1.6.35)
-  - libwebp (1.0.2):
-    - libwebp/core (= 1.0.2)
-    - libwebp/dec (= 1.0.2)
-    - libwebp/demux (= 1.0.2)
-    - libwebp/dsp (= 1.0.2)
-    - libwebp/enc (= 1.0.2)
-    - libwebp/mux (= 1.0.2)
-    - libwebp/utils (= 1.0.2)
-    - libwebp/webp (= 1.0.2)
-  - libwebp/core (1.0.2):
+  - libwebp (1.1.0):
+    - libwebp/core (= 1.1.0)
+    - libwebp/dec (= 1.1.0)
+    - libwebp/demux (= 1.1.0)
+    - libwebp/dsp (= 1.1.0)
+    - libwebp/enc (= 1.1.0)
+    - libwebp/mux (= 1.1.0)
+    - libwebp/utils (= 1.1.0)
+    - libwebp/webp (= 1.1.0)
+  - libwebp/core (1.1.0):
     - libwebp/webp
-  - libwebp/dec (1.0.2):
+  - libwebp/dec (1.1.0):
     - libwebp/core
-  - libwebp/demux (1.0.2):
+  - libwebp/demux (1.1.0):
     - libwebp/core
-  - libwebp/dsp (1.0.2):
+  - libwebp/dsp (1.1.0):
     - libwebp/core
-  - libwebp/enc (1.0.2):
+  - libwebp/enc (1.1.0):
     - libwebp/core
-  - libwebp/mux (1.0.2):
+  - libwebp/mux (1.1.0):
     - libwebp/core
-  - libwebp/utils (1.0.2):
+  - libwebp/utils (1.1.0):
     - libwebp/core
-  - libwebp/webp (1.0.2)
+  - libwebp/webp (1.1.0)
   - mozjpeg (3.3.2)
   - spectrum-folly (2019.01.21.00)
   - SpectrumCore (1.1.0):
@@ -42,7 +42,7 @@ PODS:
     - spectrum-folly (~> 2019.01.21.00)
     - SpectrumCore/Base (= 1.1.0)
   - SpectrumCore/Plugins/Webp (1.1.0):
-    - libwebp (~> 1.0.2)
+    - libwebp (~> 1.1.0)
     - spectrum-folly (~> 2019.01.21.00)
     - SpectrumCore/Base (= 1.1.0)
   - SpectrumKit (1.1.0):


### PR DESCRIPTION
Updates libwebp from 1.0.2 to 1.1.0. [Changelog](https://github.com/webmproject/libwebp/blob/1.1.0/NEWS):

```
- 12/18/2019: version 1.1.0
  * API changes:
    - libwebp:
      WebPMalloc (issue #442)
    - extras:
      WebPUnmultiplyARGB
  * alpha decode fix (issue #439)
  * toolchain updates and bug fixes
    (chromium: #1026858, #1027136, #1027409, #1028620, #1028716, #995200)
    (oss-fuzz: #19430, #19447)

- 7/4/2019: version 1.0.3
  This is a binary compatible release.
  * resize fixes for Nx1 sizes and the addition of non-opaque alpha values for
    odd sizes (issues #418, #434)
  * lossless encode/decode performance improvements
  * lossy compression performance improvement at low quality levels with flat
    content (issue #432)
  * python swig files updated to support python 3
  Tool updates:
    vwebp will now preserve the aspect ratio of images that exceed monitor
    resolution by scaling the image to fit (issue #433)
```
Are any of the API changes affecting spectrum?