### PR TITLE
Adding ELI5 video to the home page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -102,12 +102,36 @@ const Features = () => (
   </Block>
 );
 
+const VideoContainer = () => {
+  return (
+    <div className="container text--center margin-bottom--xl">
+      <div className="row">
+        <div className="col" style={{textAlign: 'center'}}>
+          <h2>Check it out in the intro video</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/kEHZJ4CvyeI"
+              title="Explain Like I'm 5: Spectrum"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 class Index extends React.Component {
   render() {
     const language = this.props.language || '';
     return (
       <div>
         <HomeSplash language={language} />
+        <VideoContainer />
         <div className="mainContainer">
           <Features />
         </div>


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc..

## Test plan:
![image](https://user-images.githubusercontent.com/12485205/154556921-f962b057-d1d9-4056-851f-6951edfa4c4a.png)
