### PR TITLE
xplat/spectrum/cpp/test/unit/plugins/jpeg/LibJpegCompressorTest.cpp: initialize in declaration order to placate -Wreorder-init-list

### DIFF
--- a/cpp/test/unit/plugins/jpeg/LibJpegCompressorTest.cpp
+++ b/cpp/test/unit/plugins/jpeg/LibJpegCompressorTest.cpp
@@ -47,8 +47,8 @@ LibJpegCompressor makeCompressor(
       .encodeRequirement =
           options.encodeRequirement.value_or(requirements::Encode{
               .format = image::formats::Jpeg,
-              .mode = requirements::Encode::Mode::Lossy,
               .quality = 80,
+              .mode = requirements::Encode::Mode::Lossy,
           }),
       .configuration = options.configuration,
   });


### PR DESCRIPTION
Summary:
This avoids the following errors:

  xplat/spectrum/cpp/test/unit/plugins/jpeg/LibJpegCompressorTest.cpp:51:15: error: ISO C++ requires field designators to be specified in declaration order; field 'mode' will be initialized after field 'quality' [-Werror,-Wreorder-init-list]

Differential Revision: D38105346

