### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/android/spectrumdefault/src/main/java/com/facebook/spectrum/DefaultPlugins.java
+++ b/android/spectrumdefault/src/main/java/com/facebook/spectrum/DefaultPlugins.java
@@ -14,7 +14,8 @@ import com.facebook.spectrum.plugins.SpectrumPluginWebp;
 
 public class DefaultPlugins {
 
-  private DefaultPlugins() {};
+  private DefaultPlugins() {}
+  ;
 
   public static SpectrumPlugin[] get() {
     return new SpectrumPlugin[] {

--- a/android/src/main/java/com/facebook/spectrum/Configuration.java
+++ b/android/src/main/java/com/facebook/spectrum/Configuration.java
@@ -166,7 +166,9 @@ public class Configuration {
         .build();
   }
 
-  /** @return A new builder to be used for creating {@link Configuration} objects. */
+  /**
+   * @return A new builder to be used for creating {@link Configuration} objects.
+   */
   public static Builder Builder() {
     return new Builder();
   }
@@ -346,7 +348,9 @@ public class Configuration {
       this.value = value;
     }
 
-    /** @return matching {@link ImageHint} for the given values. Throws otherwise */
+    /**
+     * @return matching {@link ImageHint} for the given values. Throws otherwise
+     */
     @DoNotStrip
     static ImageHint from(final int value) {
       for (ImageHint imageHint : ImageHint.values()) {
@@ -376,7 +380,9 @@ public class Configuration {
       this.value = value;
     }
 
-    /** @return matching {@link SamplingMethod} for the given values. Throws otherwise */
+    /**
+     * @return matching {@link SamplingMethod} for the given values. Throws otherwise
+     */
     @DoNotStrip
     static SamplingMethod from(final int value) {
       for (SamplingMethod samplingMethod : SamplingMethod.values()) {

--- a/android/src/main/java/com/facebook/spectrum/ISpectrum.java
+++ b/android/src/main/java/com/facebook/spectrum/ISpectrum.java
@@ -20,7 +20,9 @@ import com.facebook.spectrum.options.TransformOptions;
  */
 public interface ISpectrum {
 
-  /** @return true iff the native code loaded and initialized properly. */
+  /**
+   * @return true iff the native code loaded and initialized properly.
+   */
   boolean isAvailable();
 
   /**

--- a/android/src/main/java/com/facebook/spectrum/SpectrumTask.java
+++ b/android/src/main/java/com/facebook/spectrum/SpectrumTask.java
@@ -119,7 +119,8 @@ import javax.annotation.Nullable;
   }
 
   class Helper {
-    private Helper() {};
+    private Helper() {}
+    ;
 
     static void closeQuietly(@Nullable final Closeable closeable) {
       if (closeable == null) {

--- a/android/src/main/java/com/facebook/spectrum/image/ImagePixelSpecification.java
+++ b/android/src/main/java/com/facebook/spectrum/image/ImagePixelSpecification.java
@@ -82,7 +82,9 @@ public enum ImagePixelSpecification {
     }
   }
 
-  /** @return matching {@link ImagePixelSpecification} for the given values. Throws otherwise */
+  /**
+   * @return matching {@link ImagePixelSpecification} for the given values. Throws otherwise
+   */
   @DoNotStrip
   static ImagePixelSpecification from(
       final ColorModel colorModel,
@@ -116,7 +118,9 @@ public enum ImagePixelSpecification {
       this.value = value;
     }
 
-    /** @return matching {@link ComponentsOrder} for the given values. Throws otherwise */
+    /**
+     * @return matching {@link ComponentsOrder} for the given values. Throws otherwise
+     */
     @DoNotStrip
     static ComponentsOrder from(final int value) {
       for (ComponentsOrder componentsOrder : ComponentsOrder.values()) {
@@ -171,7 +175,9 @@ public enum ImagePixelSpecification {
       this.supportsExtraAlphaChannel = supportsExtraAlphaChannel;
     }
 
-    /** @return matching {@link ColorModel} for the given values. Throws otherwise */
+    /**
+     * @return matching {@link ColorModel} for the given values. Throws otherwise
+     */
     @DoNotStrip
     static ColorModel from(
         final String identifier,
@@ -187,6 +193,7 @@ public enum ImagePixelSpecification {
       throw new IllegalArgumentException("Unsupported PixelColorModel");
     }
   }
+
   /** The alpha info specifies the behaviour of the optional alpha channel */
   @DoNotStrip
   @Immutable
@@ -231,7 +238,9 @@ public enum ImagePixelSpecification {
       this.value = value;
     }
 
-    /** @return matching {@link AlphaInfo} for the given values. Throws otherwise */
+    /**
+     * @return matching {@link AlphaInfo} for the given values. Throws otherwise
+     */
     @DoNotStrip
     static AlphaInfo from(final int value) {
       for (AlphaInfo alphaInfo : AlphaInfo.values()) {

--- a/android/src/main/java/com/facebook/spectrum/options/Options.java
+++ b/android/src/main/java/com/facebook/spectrum/options/Options.java
@@ -43,6 +43,7 @@ public class Options {
 
   /** Options in the configuration object will override default and app-wide settings. */
   @DoNotStrip @Nullable public final Configuration configuration;
+
   /**
    * If set, will dictate the pixel specification images should be converted to before being passed
    * to the compressor. An exception will be thrown if the pixel specification doesn't fit the image

--- a/android/src/main/java/com/facebook/spectrum/requirements/EncodeRequirement.java
+++ b/android/src/main/java/com/facebook/spectrum/requirements/EncodeRequirement.java
@@ -40,7 +40,9 @@ public class EncodeRequirement {
       this.value = value;
     }
 
-    /** @return matching {@link Mode} for the given values. Throws otherwise */
+    /**
+     * @return matching {@link Mode} for the given values. Throws otherwise
+     */
     @DoNotStrip
     static Mode from(final int value) {
       for (Mode mode : Mode.values()) {

--- a/android/src/main/java/com/facebook/spectrum/requirements/ResizeRequirement.java
+++ b/android/src/main/java/com/facebook/spectrum/requirements/ResizeRequirement.java
@@ -103,7 +103,9 @@ public class ResizeRequirement {
       this.value = value;
     }
 
-    /** @return matching {@link Mode} for the given values. Throws otherwise */
+    /**
+     * @return matching {@link Mode} for the given values. Throws otherwise
+     */
     @DoNotStrip
     static Mode from(final int value) {
       for (Mode mode : Mode.values()) {

--- a/androidLibs/fbjni/java/com/facebook/jni/DestructorThread.java
+++ b/androidLibs/fbjni/java/com/facebook/jni/DestructorThread.java
@@ -48,6 +48,7 @@ public class DestructorThread {
 
   /** A list to keep all active Destructors in memory confined to the Destructor thread. */
   private static DestructorList sDestructorList;
+
   /** A thread safe stack where new Destructors are placed before being add to sDestructorList. */
   private static DestructorStack sDestructorStack;
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


